### PR TITLE
Rajout d'un fichier de log de documentation

### DIFF
--- a/Documentation/log_documentation.md
+++ b/Documentation/log_documentation.md
@@ -1,0 +1,4 @@
+# Historique de la documentation 
+
+**Mise à jour du 16/10/2017 : Groupe Marina, Hugo, Nicolas**
+**Commentaires : Fill repository Documentation + SPRINT.md**


### PR DESCRIPTION
Fichier permettant de suivre l'historique de la documentation 
Idée : rajouter un dossier contenant les présentations de chaque groupe sur leur sprint peut être intéressant